### PR TITLE
Namespace fix (and codestyle)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "composer/composer": "master@dev",
         "phpunit/phpunit": "4.*",
-        "squizlabs/php_codesniffer": "1.*"
+        "squizlabs/php_codesniffer": "^2.5"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,11 +13,7 @@
   <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
   <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
   <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
-  <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
   <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
-
-  <rule ref="Generic.Commenting.Fixme"/>
-  <rule ref="Generic.Commenting.Todo"/>
 
   <rule ref="Generic.ControlStructures.InlineControlStructure"/>
 
@@ -58,11 +54,6 @@
   <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
   <rule ref="Squiz.Classes.SelfMemberReference"/>
   <rule ref="Squiz.Classes.ValidClassName"/>
-
-  <rule ref="Squiz.CodeAnalysis.EmptyStatement"/>
-  <!--<rule ref="Squiz.Commenting.BlockComment"/>-->
-  <!-- <rule ref="Squiz.Commenting.ClassComment"/> -->
-  <!-- <rule ref="Squiz.Commenting.FunctionComment"/> -->
 
   <rule ref="Squiz.PHP.CommentedOutCode">
       <properties>

--- a/src/Compound/CompoundGenerator.php
+++ b/src/Compound/CompoundGenerator.php
@@ -2,7 +2,6 @@
 namespace Hostnet\Component\EntityPlugin\Compound;
 
 use Composer\IO\IOInterface;
-use Composer\Package\PackageInterface;
 use Hostnet\Component\EntityPlugin\EntityPackage;
 use Hostnet\Component\EntityPlugin\PackageClass;
 use Hostnet\Component\EntityPlugin\WriterInterface;

--- a/src/Compound/PackageContentProvider.php
+++ b/src/Compound/PackageContentProvider.php
@@ -25,8 +25,10 @@ class PackageContentProvider
      */
     public function getPackageContent(EntityPackage $entity_package)
     {
-        return $this->type == PackageContent::ENTITY
-            ? $entity_package->getEntityContent()
-            : $entity_package->getRepositoryContent();
+        if ($this->type == PackageContent::ENTITY) {
+            return $entity_package->getEntityContent();
+        } else {
+            return $entity_package->getRepositoryContent();
+        }
     }
 }

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -6,10 +6,7 @@ use Composer\Installer\LibraryInstaller;
 use Composer\IO\IOInterface;
 use Composer\Package\Package;
 use Composer\Package\PackageInterface;
-use Composer\Package\RootPackage;
 use Composer\Package\RootPackageInterface;
-use Composer\Repository\InstalledRepositoryInterface;
-use Composer\Script\ScriptEvents;
 
 /**
  * Custom installer to generate the various traits and interfaces for that package

--- a/src/PackagePathResolver.php
+++ b/src/PackagePathResolver.php
@@ -14,7 +14,7 @@ interface PackagePathResolver
     /**
      * Get the path containing the actual source of the application
      *
-     * @param PackageInterface $package 
+     * @param PackageInterface $package
      */
     public function getSourcePath(PackageInterface $package);
 }

--- a/src/ReflectionGenerator.php
+++ b/src/ReflectionGenerator.php
@@ -1,9 +1,6 @@
 <?php
 namespace Hostnet\Component\EntityPlugin;
 
-use Composer\IO\IOInterface;
-use Symfony\Component\Console\Output\ConsoleOutput;
-
 /**
  * A simple, light-weight generator that can be used runtime during development
  * It does not know about the composer structure, since thats expensive to build
@@ -64,7 +61,9 @@ class ReflectionGenerator
             if ($method->name === '__construct') {
                 // The interface should not contain the constructor
                 unset($methods[$key]);
+                continue;
             }
+            $methods[$key] = new ReflectionMethod($method);
         }
 
         return $methods;

--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -1,0 +1,52 @@
+<?php
+namespace Hostnet\Component\EntityPlugin;
+
+/**
+ * Wrapper around \RefelectionMethod
+ * to overload getDocComment to allow
+ * changes to the @return statement.
+ *
+ * Since Entities want to return the
+ * Generated interface they would add
+ * a @return Generated\FooInterface.
+ *
+ * This @return statement is copied
+ * over to the gererated interface
+ * that is already in the Generated
+ * sub-namespace. Thus the Generated\
+ * part should be stripped.
+ */
+class ReflectionMethod
+{
+    private $method;
+
+    public function __construct(\ReflectionMethod $method)
+    {
+        $this->method = $method;
+    }
+
+    public function getName()
+    {
+        return $this->method->getName();
+    }
+
+    public function getParameters()
+    {
+        return $this->method->getParameters();
+    }
+
+    public function isPublic()
+    {
+        return $this->method->isPublic();
+    }
+
+    public function isStatic()
+    {
+        return $this->method->isStatic();
+    }
+
+    public function getDocComment()
+    {
+        return preg_replace('/@return Generated\\\\/', '@return ', $this->method->getDocComment());
+    }
+}

--- a/test/OptionalPackageTraitTest.php
+++ b/test/OptionalPackageTraitTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Hostnet\Component\EntityPlugin;
 
-
 /**
  * More of a functional-like test to check the outputted html.
  * @author Nico Schoenmaker <nschoenmaker@hostnet.nl>

--- a/test/ReflectionGeneratorTest.php
+++ b/test/ReflectionGeneratorTest.php
@@ -1,9 +1,6 @@
 <?php
 namespace Hostnet\Component\EntityPlugin;
 
-use Composer\IO\NullIO;
-use Hostnet\EdgeCases\Entity\Generated\MultipleArgumentsTraitInterface;
-
 /**
  * More a functiononal test then a unit-test
  *

--- a/test/ReflectionMethodTest.php
+++ b/test/ReflectionMethodTest.php
@@ -1,0 +1,59 @@
+<?php
+namespace Hostnet\Component\EntityPlugin;
+
+/**
+ * @covers Hostnet\Component\EntityPlugin\ReflectionMethod
+ */
+class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
+{
+    private $method;
+
+    /**
+     * Blaah Blaah Blaaaah Cloud...
+     *
+     * @param unknown $empty
+     * @return Generated\Blyp
+     */
+    public function docBlock($param_1, array $param_2)
+    {
+        return 'quite useless, we only need the docblock...';
+    }
+
+    protected function setUp()
+    {
+        $this->method = new ReflectionMethod(new \ReflectionMethod(__CLASS__, 'docBlock'));
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals('docBlock', $this->method->getName());
+    }
+
+    public function testIsStatic()
+    {
+        $this->assertFalse($this->method->isStatic());
+    }
+
+    public function testIsPublic()
+    {
+        $this->assertTrue($this->method->isPublic());
+    }
+
+    public function testGetParameters()
+    {
+        $this->assertEquals(2, count($this->method->getParameters()));
+    }
+
+    public function testGetDocComment()
+    {
+        $expected = <<<'EOS'
+/**
+     * Blaah Blaah Blaaaah Cloud...
+     *
+     * @param unknown $empty
+     * @return Blyp
+     */
+EOS;
+        $this->assertEquals($expected, $this->method->getDocComment());
+    }
+}

--- a/test/TypeHinterTest.php
+++ b/test/TypeHinterTest.php
@@ -8,8 +8,8 @@ function parameterHints(
     \Hostnet\Component\EntityPlugin\ReflectionGenerator $full_namespace,
     ReflectionGenerator $namespace,
     \DateTime $datetime,
-    \DateTime $datetime_null = null,
-    $empty
+    $empty,
+    \DateTime $datetime_null = null
 ) {
     return 'quite useless, we only need the parameters...';
 }


### PR DESCRIPTION
`@return` statements where copied unchanged into the interface, if the '@return' statement referenced some generated class by this plugin, the namespace would be wrong, hence killing code completion in IDE's.

Also fixed all open code style issues