### PR TITLE
Allow ApeWhenBeeTrait in package C for packages A,B,C with classes Ape,Bee,Cat

### DIFF
--- a/test/Compound/CompoundEdgeCases/DeathContractTraits.php
+++ b/test/Compound/CompoundEdgeCases/DeathContractTraits.php
@@ -1,0 +1,16 @@
+<?php
+namespace Hostnet\Contract\Entity\Generated;
+
+use Hostnet\Death\Entity\DeathContractWhenProductTrait as HostnetDeathEntityBecauseProduct;
+use Hostnet\Death\Entity\DeathContractWhenClientTrait as HostnetDeathEntityBecauseClient;
+
+/**
+ * Trait of traits generated for DeathContract
+ * This is the guy that the main class needs to require, and ensures that everything is glued
+ * together
+ */
+trait DeathContractTraits
+{
+    use HostnetDeathEntityBecauseProduct;
+    use HostnetDeathEntityBecauseClient;
+}

--- a/test/PackageContentTest.php
+++ b/test/PackageContentTest.php
@@ -7,13 +7,17 @@ namespace Hostnet\Component\EntityPlugin;
 class PackageContentTest extends \PHPUnit_Framework_TestCase
 {
     private static $map = [
-        'Foo\Bar\Baz' => 'Baz.php',
-        'Foo\Bar\BazInterface' => 'BazInterface.php',
-        'Foo\Bar\BazException' => 'BazException.php',
-        'Foo\Bar\BlahTrait' => 'BlahTrait.php',
-        'Foo\Bar\BazWhenBlahTrait' => '/BazWhenBlahTrait.php',
-        'Foo\Bar\Generated\Baz' => 'Generated/Baz.php',
-        'Foo\Baz\Bar' => 'Bar.php'
+        'Foo\\Bar\\Baz' => 'Baz.php',
+        'Foo\\Bar\\BazInterface' => 'BazInterface.php',
+        'Foo\\Bar\\BazException' => 'BazException.php',
+        'Foo\\Bar\\BlahTrait' => 'BlahTrait.php',
+        'Foo\\Bar\\BazWhenBlahTrait' => '/BazWhenBlahTrait.php',
+        'Foo\\Bar\\Generated\\Baz' => 'Generated/Baz.php',
+        'Foo\\Baz\\Bar' => 'Bar.php',
+        'Hostnet\\Drink\\Entity\\Milk' => '/Milk.php',
+        'Hostnet\\Animal\\Entity\\Cow' => '/Cow.php',
+        'Hostnet\\AnimalDrink\\Entity\\MilkWhenCowTrait' => '/MilkWhenCowTrait.php',
+        'Hostnet\\AnimalDrink\\Entity\\CowWhenMilkTrait' => '/CowWhenMilkTrait.php',
     ];
 
     private $empty_content;
@@ -52,11 +56,36 @@ class PackageContentTest extends \PHPUnit_Framework_TestCase
     public function testGetOptionalTraits()
     {
         $this->assertEquals([], $this->empty_content->getOptionalTraits('Baz'));
+
+        // Optional trait for class included in own package
         $this->assertEquals(
             [new OptionalPackageTrait('Foo\Bar\BazWhenBlahTrait', '/BazWhenBlahTrait.php', 'Blah')],
             $this->content->getOptionalTraits('Baz')
         );
-        $this->assertEquals([], $this->content->getOptionalTraits('Blah'));
+
+        $animaldrink = new PackageContent(self::$map, '\\AnimalDrink\\');
+
+        // Optional trait for class included in other package
+        $this->assertEquals(
+            [
+                new OptionalPackageTrait(
+                    'Hostnet\\AnimalDrink\\Entity\\CowWhenMilkTrait',
+                    '/CowWhenMilkTrait.php',
+                    'Milk'
+                )
+            ],
+            $animaldrink->getOptionalTraits('Cow')
+        );
+        $this->assertEquals(
+            [
+                new OptionalPackageTrait(
+                    'Hostnet\\AnimalDrink\\Entity\\MilkWhenCowTrait',
+                    '/MilkWhenCowTrait.php',
+                    'Cow'
+                )
+            ],
+            $animaldrink->getOptionalTraits('Milk')
+        );
     }
 
     public function testGetTraits()


### PR DESCRIPTION
- Optional traits were not handled in the same way normal traits were.
- Fixed already visited packages lookup in the generator