### PR TITLE
Made entities that extends other entities reflect in the interfaces

### DIFF
--- a/src/Resources/templates/interface.php.twig
+++ b/src/Resources/templates/interface.php.twig
@@ -5,7 +5,8 @@ namespace {{ namespace }};
  * Implement this interface in {{ class_name }}!
  * This is a combined interface that will automatically extend to contain the required functions.
  */
-interface {{ class_name }}Interface
+interface {{ class_name }}Interface{% if parent %} extends {{ parent }}Interface{% endif %}
+
 {
 {% for method in methods %}
 {% if method.isPublic() and not method.isStatic() %}

--- a/test/Functional/Tests/GenerationTest.php
+++ b/test/Functional/Tests/GenerationTest.php
@@ -82,6 +82,10 @@ class GenerationTest extends \PHPUnit_Framework_TestCase
             file_get_contents(__DIR__ . '/expected/TypedParametersInterface.php'),
             file_get_contents($dir . '/TypedParametersInterface.php')
         );
+        self::assertEquals(
+            file_get_contents(__DIR__ . '/expected/ExtendedMissingParentClassInterface.php'),
+            file_get_contents($dir . '/ExtendedMissingParentClassInterface.php')
+        );
     }
 
     protected function tearDown()

--- a/test/Functional/Tests/expected/ExtendedMissingParentClassInterface.php
+++ b/test/Functional/Tests/expected/ExtendedMissingParentClassInterface.php
@@ -2,18 +2,12 @@
 namespace Hostnet\FunctionalFixtures\Entity\Generated;
 
 /**
- * Implement this interface in ExtendedClass!
+ * Implement this interface in ExtendedMissingParentClass!
  * This is a combined interface that will automatically extend to contain the required functions.
  */
-interface ExtendedClassInterface extends BaseClassInterface
+interface ExtendedMissingParentClassInterface
 {
 
     
     public function someAnotherMethod();
-
-    
-    public function someMethod();
-
-    
-    public function someOtherMethod();
 }

--- a/test/Functional/src/Entity/ExtendedMissingParentClass.php
+++ b/test/Functional/src/Entity/ExtendedMissingParentClass.php
@@ -1,0 +1,11 @@
+<?php
+namespace Hostnet\FunctionalFixtures\Entity;
+
+
+class ExtendedMissingParentClass extends \stdClass
+{
+    public function someAnotherMethod()
+    {
+        
+    }
+}

--- a/test/ReflectionGeneratorTest.php
+++ b/test/ReflectionGeneratorTest.php
@@ -26,6 +26,37 @@ class ReflectionGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($actual, file_get_contents(__DIR__ . '/Functional/Tests/expected/BaseClassInterface.php'));
     }
 
+    public function testGenerateInIsolationWithParent()
+    {
+        $base_dir    = __DIR__ . '/Functional/src/Entity';
+
+        ReflectionGenerator::generateInIsolation('Hostnet\\FunctionalFixtures\\Entity\\ExtendedClass');
+
+        $actual = file_get_contents($base_dir . '/Generated/ExtendedClassInterface.php');
+
+        unlink($base_dir . '/Generated/ExtendedClassInterface.php');
+        rmdir($base_dir . '/Generated');
+
+        $this->assertEquals($actual, file_get_contents(__DIR__ . '/Functional/Tests/expected/ExtendedClassInterface.php'));
+    }
+
+    public function testGenerateInIsolationWithMissingParent()
+    {
+        $base_dir    = __DIR__ . '/Functional/src/Entity';
+
+        ReflectionGenerator::generateInIsolation('Hostnet\\FunctionalFixtures\\Entity\\ExtendedMissingParentClass');
+
+        $actual = file_get_contents($base_dir . '/Generated/ExtendedMissingParentClassInterface.php');
+
+        unlink($base_dir . '/Generated/ExtendedMissingParentClassInterface.php');
+        rmdir($base_dir . '/Generated');
+
+        $this->assertEquals(
+            $actual, 
+            file_get_contents(__DIR__ . '/Functional/Tests/expected/ExtendedMissingParentClassInterface.php')
+        );
+    }
+
     public function testGenerate()
     {
         //include_once __DIR__ . '/EdgeCases/' . $package_class->getShortName() . '.php';
@@ -53,6 +84,19 @@ class ReflectionGeneratorTest extends \PHPUnit_Framework_TestCase
         $base_dir = __DIR__ . '/Functional/src/Entity';
 
         unlink($base_dir . '/Generated/BaseClassInterface.php');
+        rmdir($base_dir . '/Generated');
+    }
+
+    public function testMainWithParent()
+    {
+        // functionallity is already tested, test for smoke...
+        ReflectionGenerator::main(
+            'Hostnet\\FunctionalFixtures\\Entity\\ExtendedClass'
+        );
+
+        $base_dir = __DIR__ . '/Functional/src/Entity';
+
+        unlink($base_dir . '/Generated/ExtendedClassInterface.php');
         rmdir($base_dir . '/Generated');
     }
 }


### PR DESCRIPTION
This pull request makes sure that any inheritance model that is present in the entities is also reflected in the interfaces. So if you have the following case:
```php
class A {}
class B extends A {}
```
The interfaces will be generated as follows:
```php
interface AInterface {}
interface BInterface extends AInterface {}
```

This only works in the entities are located in the same folder. So if you extend something that is located in a different folder, the parent class will not be used. This restriction is here to keep the interfaces clean and prevent a lot of code dealing with imports and use statements.