### PR TITLE
fix default values

### DIFF
--- a/src/Resources/templates/parameters.php.twig
+++ b/src/Resources/templates/parameters.php.twig
@@ -12,7 +12,8 @@
     {% if parameter.isPassedByReference() %}&{% endif -%}
     {% if parameter.isVariadic() %}...{% endif -%}
     ${{ parameter.name -}}
-
-    {% if parameter.isDefaultValueAvailable() and parameter.defaultValue is null %} = null{% endif -%}
+    {% if parameter.isOptional() and parameter.isDefaultValueAvailable() -%}
+        {{- ' = null' -}}
+    {%- endif -%}
     {% if not loop.last %}, {% endif -%}
 {% endfor %}

--- a/test/Fixtures/NullableParamsInterface.php
+++ b/test/Fixtures/NullableParamsInterface.php
@@ -26,17 +26,17 @@ interface NullableParamsInterface
     /**
      * @param int|null $start
      */
-    public function defaultValueNullableParam(?int $start);
+    public function defaultValueNullableParam(?int $start = null);
 
     /**
      * @param string|null $start
      */
-    public function defaultValueStringNullNullableParam(?string $start);
+    public function defaultValueStringNullNullableParam(?string $start = null);
 
     /**
      * @param int|null $start
      */
-    public function nullableReference(?int &$start);
+    public function nullableReference(?int &$start = null);
 
     /**
      * @param int[]|null[] ...$start

--- a/test/Functional/Tests/GenerationTest.php
+++ b/test/Functional/Tests/GenerationTest.php
@@ -91,6 +91,10 @@ class GenerationTest extends TestCase
             file_get_contents(__DIR__ . '/expected/ExtendedMissingParentClassInterface.php'),
             file_get_contents($dir . '/ExtendedMissingParentClassInterface.php')
         );
+        self::assertEquals(
+            file_get_contents(__DIR__ . '/expected/DefaultParametersInterface.php'),
+            file_get_contents($dir . '/DefaultParametersInterface.php')
+        );
     }
 
     protected function tearDown()

--- a/test/Functional/Tests/expected/DefaultParametersInterface.php
+++ b/test/Functional/Tests/expected/DefaultParametersInterface.php
@@ -1,0 +1,28 @@
+<?php
+namespace Hostnet\FunctionalFixtures\Entity\Generated;
+
+/**
+ * Implement this interface in DefaultParameters!
+ * This is a combined interface that will automatically extend to contain the required functions.
+ */
+interface DefaultParametersInterface
+{
+
+    /**
+     * @param bool $bool
+     */
+    public function oneParameter($bool = null);
+
+    /**
+     * @param bool   $bool
+     * @param string $string
+     */
+    public function twoParameters($bool = null, $string = null);
+
+    /**
+     * @param bool           $bool
+     * @param string         $string
+     * @param \DateTime|null $date
+     */
+    public function threeParameters($bool = null, $string = null, \DateTime $date = null);
+}

--- a/test/Functional/src/Entity/DefaultParameters.php
+++ b/test/Functional/src/Entity/DefaultParameters.php
@@ -1,0 +1,29 @@
+<?php
+namespace Hostnet\FunctionalFixtures\Entity;
+
+class DefaultParameters
+{
+    /**
+     * @param bool $bool
+     */
+    public function oneParameter($bool = true)
+    {
+    }
+
+    /**
+     * @param bool   $bool
+     * @param string $string
+     */
+    public function twoParameters($bool = true, $string = 'empty')
+    {
+    }
+
+    /**
+     * @param bool           $bool
+     * @param string         $string
+     * @param \DateTime|null $date
+     */
+    public function threeParameters($bool = true, $string = 'empty', \DateTime $date = null)
+    {
+    }
+}


### PR DESCRIPTION
in the old version default values always were null due to unavailability of the defaultValue param. This restores this accidental correct behaviour