### PR TITLE
Propagate typehint values to interface instead of null

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "doctrine/annotations":        "^1.3",
         "phpdocumentor/type-resolver": "^0.2.0",
         "symfony/filesystem":          "^2.3.0 || ^3.0.0",
-        "twig/twig":                   "^2.0 || 1.13"
+        "twig/twig":                   "^2.0 || 1.14.2"
     },
     "require-dev": {
         "composer/composer":  "^1.1.0",

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -114,4 +114,51 @@ class ReflectionParameter
     {
         return $this->parameter->getDefaultValue();
     }
+
+    /**
+     * @return bool
+     */
+    public function isDefaultValueConstant()
+    {
+        return $this->parameter->isDefaultValueConstant();
+    }
+
+    /**
+     * @return string
+     */
+    public function getDefaultValueConstantName()
+    {
+        return $this->parameter->getDefaultValueConstantName();
+    }
+
+    /**
+     * Returns the default value in a manner which is safe to use in PHP code
+     * as a default value.
+     *
+     * @throws \ReflectionException If called on property without default value
+     * @return string
+     */
+    public function getPhpSafeDefaultValue()
+    {
+        $value     = $this->getDefaultValue();
+        $is_string = $this->hasType() && $this->getType()->getName() === 'string';
+
+        if ($value === true) {
+            return 'true';
+        } elseif ($value === false) {
+            return 'false';
+        } elseif ($this->isDefaultValueConstant()) {
+            if (strpos($this->getDefaultValueConstantName(), 'self') === 0) {
+                return $this->getDefaultValueConstantName();
+            }
+            return '\\' . $this->getDefaultValueConstantName();
+        } elseif (is_array($value)) {
+            return '[]';
+        } elseif (is_null($value)) {
+            return 'null';
+        } elseif (is_numeric($value) && !$is_string) {
+            return (string) $value;
+        }
+        return 'null';
+    }
 }

--- a/src/Resources/templates/parameters.php.twig
+++ b/src/Resources/templates/parameters.php.twig
@@ -12,8 +12,8 @@
     {% if parameter.isPassedByReference() %}&{% endif -%}
     {% if parameter.isVariadic() %}...{% endif -%}
     ${{ parameter.name -}}
-    {% if parameter.isOptional() and parameter.isDefaultValueAvailable() -%}
-        {{- ' = null' -}}
+    {% if parameter.isDefaultValueAvailable() -%}
+        {{- ' = ' ~ parameter.getPhpSafeDefaultValue() -}}
     {%- endif -%}
     {% if not loop.last %}, {% endif -%}
 {% endfor %}

--- a/test/Fixtures/DefaultValueParams.php
+++ b/test/Fixtures/DefaultValueParams.php
@@ -1,0 +1,182 @@
+<?php
+namespace Hostnet\Component\EntityPlugin\Fixtures;
+
+class DefaultValueParams
+{
+    const FOO = 'BAR';
+
+    /**
+     * @param int $int
+     */
+    public function defaultIntValue(int $int = 1)
+    {
+    }
+    /**
+     * @param int $int
+     */
+    public function defaultIntNullValue(int $int = null)
+    {
+    }
+
+    /**
+     * @param int $int
+     */
+    public function defaultIntWithoutTypeHintValue($int = 1)
+    {
+    }
+
+    /**
+     * @param float $float
+     */
+    public function defaultFloatValue(float $float = 1.337)
+    {
+    }
+
+    /**
+     * @param float $float
+     */
+    public function defaultFloatWithoutTypeHintValue($float = 1.337)
+    {
+    }
+
+    /**
+     * @param float $float
+     */
+    public function defaultFloatNullValue(float $float = null)
+    {
+    }
+
+    /**
+     * @param bool $bool
+     */
+    public function defaultBoolFalseValue(bool $bool = false)
+    {
+    }
+
+    /**
+     * @param bool $bool
+     */
+    public function defaultBoolTrueValue(bool $bool = true)
+    {
+    }
+
+    /**
+     * @param bool $bool
+     */
+    public function defaultBoolNullValue(bool $bool = null)
+    {
+    }
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringValue(string $string = 'string')
+    {
+    }
+
+    /**
+     * @param string $string
+     */
+    public function defaultNastyStringValue(string $string = '""')
+    {
+    }
+
+    /**
+     * @param string $string
+     */
+    public function defaultNullStringValue(string $string = 'null')
+    {
+    }
+
+    /**
+     * @param string $string
+     */
+    public function defaultFunkyStringValue(string $string = "''")
+    {
+    }
+
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringNullValue(string $string = null)
+    {
+    }
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringWithoutTypeHint($string = 'string')
+    {
+    }
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringWhichIsInt(string $string = '1')
+    {
+    }
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringConstantRoot($string = \DateTime::ATOM)
+    {
+    }
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringConstantSelf($string = self::FOO)
+    {
+    }
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringConstant($string = DefaultValueParams::FOO)
+    {
+    }
+
+    /**
+     * @param array $array
+     */
+    public function defaultArrayValue(array $array = [])
+    {
+    }
+
+    /**
+     * @param array $array
+     */
+    public function defaultArrayOldValue(array $array = array())
+    {
+    }
+
+    /**
+     * @param array $array
+     */
+    public function defaultArrayNullValue(array $array = null)
+    {
+    }
+
+    /**
+     * @param \DateTime|null $date_time
+     */
+    public function defaultDateTimeNullValue(\DateTime $date_time = null)
+    {
+    }
+
+    /**
+     * @param callable $date_time
+     */
+    public function defaultCallableNullValue(callable $callable = null)
+    {
+    }
+
+    /**
+     * Docs
+     */
+    public function defaultSelfNullValue(self $self = null)
+    {
+    }
+}

--- a/test/Fixtures/DefaultValueParamsInterface.php
+++ b/test/Fixtures/DefaultValueParamsInterface.php
@@ -1,0 +1,135 @@
+<?php
+namespace Hostnet\Component\EntityPlugin\Fixtures\Generated;
+
+/**
+ * Implement this interface in DefaultValueParams!
+ * This is a combined interface that will automatically extend to contain the required functions.
+ */
+interface DefaultValueParamsInterface
+{
+
+    /**
+     * @param int $int
+     */
+    public function defaultIntValue(int $int = 1);
+
+    /**
+     * @param int $int
+     */
+    public function defaultIntNullValue(int $int = null);
+
+    /**
+     * @param int $int
+     */
+    public function defaultIntWithoutTypeHintValue($int = 1);
+
+    /**
+     * @param float $float
+     */
+    public function defaultFloatValue(float $float = 1.337);
+
+    /**
+     * @param float $float
+     */
+    public function defaultFloatWithoutTypeHintValue($float = 1.337);
+
+    /**
+     * @param float $float
+     */
+    public function defaultFloatNullValue(float $float = null);
+
+    /**
+     * @param bool $bool
+     */
+    public function defaultBoolFalseValue(bool $bool = false);
+
+    /**
+     * @param bool $bool
+     */
+    public function defaultBoolTrueValue(bool $bool = true);
+
+    /**
+     * @param bool $bool
+     */
+    public function defaultBoolNullValue(bool $bool = null);
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringValue(string $string = null);
+
+    /**
+     * @param string $string
+     */
+    public function defaultNastyStringValue(string $string = null);
+
+    /**
+     * @param string $string
+     */
+    public function defaultNullStringValue(string $string = null);
+
+    /**
+     * @param string $string
+     */
+    public function defaultFunkyStringValue(string $string = null);
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringNullValue(string $string = null);
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringWithoutTypeHint($string = null);
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringWhichIsInt(string $string = null);
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringConstantRoot($string = \DateTime::ATOM);
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringConstantSelf($string = self::FOO);
+
+    /**
+     * @param string $string
+     */
+    public function defaultStringConstant($string = \Hostnet\Component\EntityPlugin\Fixtures\DefaultValueParams::FOO);
+
+    /**
+     * @param array $array
+     */
+    public function defaultArrayValue(array $array = []);
+
+    /**
+     * @param array $array
+     */
+    public function defaultArrayOldValue(array $array = []);
+
+    /**
+     * @param array $array
+     */
+    public function defaultArrayNullValue(array $array = null);
+
+    /**
+     * @param \DateTime|null $date_time
+     */
+    public function defaultDateTimeNullValue(\DateTime $date_time = null);
+
+    /**
+     * @param callable $date_time
+     */
+    public function defaultCallableNullValue(callable $callable = null);
+
+    /**
+     * Docs
+     */
+    public function defaultSelfNullValue(self $self = null);
+}

--- a/test/Fixtures/NullableParamsInterface.php
+++ b/test/Fixtures/NullableParamsInterface.php
@@ -26,7 +26,7 @@ interface NullableParamsInterface
     /**
      * @param int|null $start
      */
-    public function defaultValueNullableParam(?int $start = null);
+    public function defaultValueNullableParam(?int $start = 2);
 
     /**
      * @param string|null $start
@@ -36,7 +36,7 @@ interface NullableParamsInterface
     /**
      * @param int|null $start
      */
-    public function nullableReference(?int &$start = null);
+    public function nullableReference(?int &$start = 0);
 
     /**
      * @param int[]|null[] ...$start

--- a/test/Functional/Tests/expected/DefaultParametersInterface.php
+++ b/test/Functional/Tests/expected/DefaultParametersInterface.php
@@ -11,18 +11,18 @@ interface DefaultParametersInterface
     /**
      * @param bool $bool
      */
-    public function oneParameter($bool = null);
+    public function oneParameter($bool = true);
 
     /**
      * @param bool   $bool
      * @param string $string
      */
-    public function twoParameters($bool = null, $string = null);
+    public function twoParameters($bool = true, $string = null);
 
     /**
      * @param bool           $bool
      * @param string         $string
      * @param \DateTime|null $date
      */
-    public function threeParameters($bool = null, $string = null, \DateTime $date = null);
+    public function threeParameters($bool = true, $string = null, \DateTime $date = null);
 }

--- a/test/ReflectionGeneratorTest.php
+++ b/test/ReflectionGeneratorTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Hostnet\Component\EntityPlugin;
 
+use Hostnet\Component\EntityPlugin\Fixtures\DefaultValueParams;
 use Hostnet\Component\EntityPlugin\Fixtures\ExtendedReturnType;
 use Hostnet\Component\EntityPlugin\Fixtures\NullableParams;
 use Hostnet\Component\EntityPlugin\Fixtures\ReturnType;
@@ -136,6 +137,24 @@ class ReflectionGeneratorTest extends TestCase
         $actual   = file_get_contents(__DIR__ . '/Fixtures/Generated/NullableParamsInterface.php');
 
         unlink(__DIR__ . '/Fixtures/Generated/NullableParamsInterface.php');
+        rmdir(__DIR__ . '/Fixtures/Generated');
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testGenerateWithDefaultValueParams()
+    {
+        if (PHP_MAJOR_VERSION < 7) {
+            $this->markTestSkipped('Scalar argument types are not available in PHP <7');
+        }
+
+        $package_class = new PackageClass(DefaultValueParams::class, __DIR__ . '/Fixtures/DefaultValueParams.php');
+        $this->reflection_generator->generate($package_class);
+
+        $expected = file_get_contents(__DIR__ . '/Fixtures/DefaultValueParamsInterface.php');
+        $actual   = file_get_contents(__DIR__ . '/Fixtures/Generated/DefaultValueParamsInterface.php');
+
+        unlink(__DIR__ . '/Fixtures/Generated/DefaultValueParamsInterface.php');
         rmdir(__DIR__ . '/Fixtures/Generated');
 
         $this->assertSame($expected, $actual);


### PR DESCRIPTION
Current behaviour: each optional parameter of the generated interface is generated as `$param = null`.

Since PHP 7.1.0 the following sample gives an error:
```
Fatal error: Declaration of Foo::bar(int $baz = 1) must be compatible with FooInterface::bar(?int $baz = NULL) in /in/XrmhZ on line 8 
```

```php
interface FooInterface
{
    public function bar(int $baz = null);
}

class Foo implements FooInterface
{
    public function bar(int $baz = 1)
    {
        
    }
}
```
See https://3v4l.org/XrmhZ for an executable example.

This partially fixes that problem. For string values we still generate `= null`. Did not yet find a proper way to handle the escaping here.