### PR TITLE
Allow Symfony 4, PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,13 @@
         "composer-plugin-api":         "^1.0.0",
         "doctrine/annotations":        "^1.3",
         "phpdocumentor/type-resolver": "0.*,>=0.2.0",
-        "symfony/filesystem":          "^2.3.0 || ^3.0.0",
+        "symfony/filesystem":          "^2.3.0 || ^3.0.0 || ^4.0.0",
         "twig/twig":                   "^2.0 || ^1.14.2"
     },
     "require-dev": {
         "composer/composer":  "^1.1.0",
         "hostnet/phpcs-tool": "^4.0.8",
-        "phpunit/phpunit":    "^5.4.3"
+        "phpunit/phpunit":    "^5.4.3 || ^6.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/test/EntityPackageBuilderTest.php
+++ b/test/EntityPackageBuilderTest.php
@@ -6,7 +6,7 @@ use Composer\Package\Package;
 use phpunit\framework\TestCase;
 
 /**
- * @covers Hostnet\Component\EntityPlugin\EntityPackageBuilder
+ * @covers \Hostnet\Component\EntityPlugin\EntityPackageBuilder
  */
 class EntityPackageBuilderTest extends TestCase
 {
@@ -26,6 +26,8 @@ class EntityPackageBuilderTest extends TestCase
 
         $builder         = new EntityPackageBuilder($mock, $packages);
         $entity_packages = $builder->getEntityPackages();
+
+        self::assertTrue(is_array($entity_packages));
 
         foreach ($expected_required_packages as $package_name => $required_packages) {
             $actual_required = [];

--- a/test/PluginTest.php
+++ b/test/PluginTest.php
@@ -5,7 +5,7 @@ use Composer\Config;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Hostnet\Component\EntityPlugin\Plugin
+ * @covers \Hostnet\Component\EntityPlugin\Plugin
  */
 class PluginTest extends TestCase
 {
@@ -17,7 +17,7 @@ class PluginTest extends TestCase
         $prophecy->getDownloadManager()->willReturn(null);
         $composer = $prophecy->reveal();
         $io       = $this->prophesize('Composer\IO\IOInterface')->reveal();
-        $plugin->activate($composer, $io);
+        self::assertNull($plugin->activate($composer, $io));
     }
 
     public function testGetSubscribedEvents()

--- a/test/ReflectionParameterTest.php
+++ b/test/ReflectionParameterTest.php
@@ -1,12 +1,13 @@
 <?php
 namespace Hostnet\Component\EntityPlugin;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputArgument;
 
 /**
  * @covers \Hostnet\Component\EntityPlugin\ReflectionParameter
  */
-class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
+class ReflectionParameterTest extends TestCase
 {
     const FOO = 'BAR';
 

--- a/test/ReflectionTypePolyFillTest.php
+++ b/test/ReflectionTypePolyFillTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Hostnet\Component\EntityPlugin;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Hostnet\Component\EntityPlugin\ReflectionTypePolyFill
  */
-class ReflectionTypePolyFillTest extends \PHPUnit_Framework_TestCase
+class ReflectionTypePolyFillTest extends TestCase
 {
     public function testGetName()
     {

--- a/test/ReflectionTypeTest.php
+++ b/test/ReflectionTypeTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Hostnet\Component\EntityPlugin;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Hostnet\Component\EntityPlugin\ReflectionType
  */
-class ReflectionTypeTest extends \PHPUnit_Framework_TestCase
+class ReflectionTypeTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
Don't think any changes were needed for Symfony 4, but needed the latest phpunit to be even able to install it.