### PR TITLE
parse @throws like @return and @param in the docblock

### DIFF
--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -90,7 +90,7 @@ class ReflectionMethod
      */
     public function getDocComment()
     {
-        $pattern = '/@(return|param)\s+((?:[\$\w\\\\]+(?:\[\])?(?:\s*[|]\s*[\$\w\\\\]+(?:\[\])?)*))(\s|$)/';
+        $pattern = '/@(return|param|throws)\s+((?:[\$\w\\\\]+(?:\[\])?(?:\s*[|]\s*[\$\w\\\\]+(?:\[\])?)*))(\s|$)/';
 
         return preg_replace_callback($pattern, [$this, 'processDocMatch'], $this->method->getDocComment());
     }

--- a/test/Functional/Tests/GenerationTest.php
+++ b/test/Functional/Tests/GenerationTest.php
@@ -99,6 +99,10 @@ class GenerationTest extends TestCase
             __DIR__.'/expected/WithTraitClassInterface.php',
             $dir.'/WithTraitClassInterface.php'
         );
+        self::assertFileEquals(
+            __DIR__.'/expected/TypedExceptionsInterface.php',
+            $dir.'/TypedExceptionsInterface.php'
+        );
     }
 
     protected function tearDown(): void

--- a/test/Functional/Tests/expected/TypedExceptionsInterface.php
+++ b/test/Functional/Tests/expected/TypedExceptionsInterface.php
@@ -1,0 +1,25 @@
+<?php
+namespace Hostnet\FunctionalFixtures\Entity\Generated;
+
+/**
+ * Implement this interface in TypedExceptions!
+ * This is a combined interface that will automatically extend to contain the required functions.
+ */
+interface TypedExceptionsInterface
+{
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function throwGlobalException();
+
+    /**
+     * @throws \Hostnet\FunctionalFixtures\Exception\DomainException
+     */
+    public function throwImportedException();
+
+    /**
+     * @throws \Hostnet\FunctionalFixtures\Exception\AnotherDomainException
+     */
+    public function throwNamespacedException();
+}

--- a/test/Functional/src/Entity/TypedExceptions.php
+++ b/test/Functional/src/Entity/TypedExceptions.php
@@ -1,0 +1,32 @@
+<?php
+namespace Hostnet\FunctionalFixtures\Entity;
+
+use Hostnet\FunctionalFixtures\Exception\AnotherDomainException;
+use Hostnet\FunctionalFixtures\Exception\DomainException;
+
+class TypedExceptions
+{
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function throwGlobalException()
+    {
+        throw new \InvalidArgumentException();
+    }
+
+    /**
+     * @throws DomainException
+     */
+    public function throwImportedException()
+    {
+        throw new DomainException();
+    }
+
+    /**
+     * @throws \Hostnet\FunctionalFixtures\Exception\AnotherDomainException
+     */
+    public function throwNamespacedException()
+    {
+        throw new AnotherDomainException();
+    }
+}

--- a/test/Functional/src/Exception/AnotherDomainException.php
+++ b/test/Functional/src/Exception/AnotherDomainException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Hostnet\FunctionalFixtures\Exception;
+
+class AnotherDomainException extends \RuntimeException
+{
+}

--- a/test/Functional/src/Exception/DomainException.php
+++ b/test/Functional/src/Exception/DomainException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Hostnet\FunctionalFixtures\Exception;
+
+class DomainException extends \RuntimeException
+{
+}


### PR DESCRIPTION
fixes #53 