### PR TITLE
Move trait to a seperate test

### DIFF
--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -90,7 +90,7 @@ class ReflectionMethod
      */
     public function getDocComment()
     {
-        $pattern = '/@(return|param)\s+((?:[\w\\\\]+(?:\[\])?(?:\s*[|]\s*[\w\\\\]+(?:\[\])?)*))(\s|$)/';
+        $pattern = '/@(return|param)\s+((?:[\$\w\\\\]+(?:\[\])?(?:\s*[|]\s*[\$\w\\\\]+(?:\[\])?)*))(\s|$)/';
 
         return preg_replace_callback($pattern, [$this, 'processDocMatch'], $this->method->getDocComment());
     }
@@ -115,6 +115,11 @@ class ReflectionMethod
      */
     private function qualifyType($type)
     {
+        // "Type" is a variable, i.e. $this.
+        if ('$' === $type[0]) {
+            return $type;
+        }
+
         // Type is fully qualified.
         if ('\\' === $type[0]) {
             return $type;

--- a/test/Fixtures/ExtraTrait.php
+++ b/test/Fixtures/ExtraTrait.php
@@ -1,11 +1,10 @@
 <?php
-namespace Hostnet\FunctionalFixtures\Entity;
+namespace Hostnet\Component\EntityPlugin\Fixtures;
 
 trait ExtraTrait
 {
     /**
      * I am from a trait
-     * @return $this|WithTraitClass
      */
     public function extra()
     {

--- a/test/Fixtures/Reflection.php
+++ b/test/Fixtures/Reflection.php
@@ -1,8 +1,6 @@
 <?php
 namespace Hostnet\Component\EntityPlugin\Fixtures;
 
-use Hostnet\FunctionalFixtures\Entity\ExtraTrait;
-
 class Reflection
 {
     use ExtraTrait;

--- a/test/Fixtures/Reflection.php
+++ b/test/Fixtures/Reflection.php
@@ -12,7 +12,7 @@ class Reflection
      * @param unknown $empty
      * @param \Exception $fully_qualified
      * @param array[] $array_of_arrays
-     * @return Generated\Blyp
+     * @return Generated\Blyp|$this
      */
     public function docBlock($param_1, array $param_2, \Exception $fully_qualified)
     {
@@ -29,7 +29,7 @@ class Reflection
      * @param \Hostnet\Component\EntityPlugin\Fixtures\unknown $empty
      * @param \Exception $fully_qualified
      * @param array[] $array_of_arrays
-     * @return Blyp
+     * @return Blyp|$this
      */
 EOS;
     }

--- a/test/Functional/Tests/GenerationTest.php
+++ b/test/Functional/Tests/GenerationTest.php
@@ -63,37 +63,41 @@ class GenerationTest extends TestCase
 
         // test the output
         $dir = __DIR__ . '/../src/Entity/Generated';
-        self::assertEquals(
-            file_get_contents(__DIR__ . '/expected/BaseClassInterface.php'),
-            file_get_contents($dir . '/BaseClassInterface.php')
+        self::assertFileEquals(
+            __DIR__.'/expected/BaseClassInterface.php',
+            $dir.'/BaseClassInterface.php'
         );
-        self::assertEquals(
-            file_get_contents(__DIR__ . '/expected/ExtendedClassInterface.php'),
-            file_get_contents($dir . '/ExtendedClassInterface.php')
+        self::assertFileEquals(
+            __DIR__.'/expected/ExtendedClassInterface.php',
+            $dir.'/ExtendedClassInterface.php'
         );
-        self::assertEquals(
-            file_get_contents(__DIR__ . '/expected/ConstructShouldNotBePresentInterface.php'),
-            file_get_contents($dir . '/ConstructShouldNotBePresentInterface.php')
+        self::assertFileEquals(
+            __DIR__.'/expected/ConstructShouldNotBePresentInterface.php',
+            $dir.'/ConstructShouldNotBePresentInterface.php'
         );
-        self::assertEquals(
-            file_get_contents(__DIR__ . '/expected/MultipleArgumentsInterface.php'),
-            file_get_contents($dir . '/MultipleArgumentsInterface.php')
+        self::assertFileEquals(
+            __DIR__.'/expected/MultipleArgumentsInterface.php',
+            $dir.'/MultipleArgumentsInterface.php'
         );
-        self::assertEquals(
-            file_get_contents(__DIR__ . '/expected/TypedParametersInterface.php'),
-            file_get_contents($dir . '/TypedParametersInterface.php')
+        self::assertFileEquals(
+            __DIR__.'/expected/TypedParametersInterface.php',
+            $dir.'/TypedParametersInterface.php'
         );
-        self::assertEquals(
-            file_get_contents(__DIR__ . '/expected/VariadicTypedParametersInterface.php'),
-            file_get_contents($dir . '/VariadicTypedParametersInterface.php')
+        self::assertFileEquals(
+            __DIR__.'/expected/VariadicTypedParametersInterface.php',
+            $dir.'/VariadicTypedParametersInterface.php'
         );
-        self::assertEquals(
-            file_get_contents(__DIR__ . '/expected/ExtendedMissingParentClassInterface.php'),
-            file_get_contents($dir . '/ExtendedMissingParentClassInterface.php')
+        self::assertFileEquals(
+            __DIR__.'/expected/ExtendedMissingParentClassInterface.php',
+            $dir.'/ExtendedMissingParentClassInterface.php'
         );
-        self::assertEquals(
-            file_get_contents(__DIR__ . '/expected/DefaultParametersInterface.php'),
-            file_get_contents($dir . '/DefaultParametersInterface.php')
+        self::assertFileEquals(
+            __DIR__.'/expected/DefaultParametersInterface.php',
+            $dir.'/DefaultParametersInterface.php'
+        );
+        self::assertFileEquals(
+            __DIR__.'/expected/WithTraitClassInterface.php',
+            $dir.'/WithTraitClassInterface.php'
         );
     }
 

--- a/test/Functional/Tests/expected/TypedParametersInterface.php
+++ b/test/Functional/Tests/expected/TypedParametersInterface.php
@@ -23,9 +23,4 @@ interface TypedParametersInterface
     /**
      */
     public function aNamespacedArgument(\Hostnet\Component\EntityPlugin\ReflectionGenerator $generator);
-
-    /**
-     * I am from a trait
-     */
-    public function extra();
 }

--- a/test/Functional/Tests/expected/WithTraitClassInterface.php
+++ b/test/Functional/Tests/expected/WithTraitClassInterface.php
@@ -10,7 +10,7 @@ interface WithTraitClassInterface
 
     /**
      * I am from a trait
-     * @return $this|WithTraitClass
+     * @return $this|\Hostnet\FunctionalFixtures\Entity\WithTraitClass
      */
     public function extra();
 }

--- a/test/Functional/Tests/expected/WithTraitClassInterface.php
+++ b/test/Functional/Tests/expected/WithTraitClassInterface.php
@@ -1,0 +1,16 @@
+<?php
+namespace Hostnet\FunctionalFixtures\Entity\Generated;
+
+/**
+ * Implement this interface in WithTraitClass!
+ * This is a combined interface that will automatically extend to contain the required functions.
+ */
+interface WithTraitClassInterface
+{
+
+    /**
+     * I am from a trait
+     * @return $this|WithTraitClass
+     */
+    public function extra();
+}

--- a/test/Functional/src/Entity/TypedParameters.php
+++ b/test/Functional/src/Entity/TypedParameters.php
@@ -5,8 +5,6 @@ use Hostnet\Component\EntityPlugin\ReflectionGenerator;
 
 class TypedParameters
 {
-    use ExtraTrait;
-
     /**
      */
     public function oneParameter(\DateTime $date)

--- a/test/Functional/src/Entity/WithTraitClass.php
+++ b/test/Functional/src/Entity/WithTraitClass.php
@@ -1,0 +1,7 @@
+<?php
+namespace Hostnet\FunctionalFixtures\Entity;
+
+class WithTraitClass
+{
+    use ExtraTrait;
+}


### PR DESCRIPTION
Note that WithTraitClassInterface contains a bug.
`Hostnet\FunctionalFixtures\Entity\Generated\WithTraitClass` is being typehinted, but this class does not exist.