### PR TITLE
update phpdocumentor/type-resolver version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php":                         ">=7.2",
         "composer-plugin-api":         "^2.0.0",
         "doctrine/annotations":        "^1.3",
-        "phpdocumentor/type-resolver": "0.*,>=0.6.0",
+        "phpdocumentor/type-resolver": "^1.4.0",
         "symfony/filesystem":          "^4.4||^5.0",
         "twig/twig":                   "^2.7.2||^3.0"
     },
@@ -15,9 +15,6 @@
         "composer/composer":  "^2.0.0",
         "hostnet/phpcs-tool": "^8.3.17",
         "phpunit/phpunit":    "^8.0"
-    },
-    "conflict": {
-        "phpdocumentor/type-resolver": ">=0.7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Current version conflicts with later versions of phpspec/prophecy, which requires on phpdocumentor/reflection-docblock, that has a dependency on phpdocumentor/type-resolver.