### PR TITLE
Remove unused doctrine/annotations dependency, dropping PHP <8.3 support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
+        php-versions: ['8.3','8.4']
     name: PHP ${{ matrix.php-versions }}
     steps:
       -   uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "php":                         "^8.1",
         "composer-plugin-api":         "^2.0.0",
-        "doctrine/annotations":        "^1.13.2",
         "phpdocumentor/type-resolver": "^1.4.0",
         "symfony/filesystem":          "^5.4||^6.0",
         "twig/twig":                   "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Installer for all the Hostnet Doctrine entity libraries",
     "license":     "MIT",
     "require": {
-        "php":                         "^8.1",
+        "php":                         "^8.3",
         "composer-plugin-api":         "^2.0.0",
         "phpdocumentor/type-resolver": "^1.4.0",
         "symfony/filesystem":          "^5.4||^6.0",

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -23,9 +23,9 @@ use Composer\Package\RootPackageInterface;
  */
 class Installer extends LibraryInstaller implements PackagePathResolverInterface
 {
-    private const PACKAGE_TYPE            = 'hostnet-entity';
-    private const EXTRA_ENTITY_BUNDLE_DIR = 'entity-bundle-dir';
-    public const GENERATE_INTERFACES      = 'generate-interfaces';
+    private const string PACKAGE_TYPE            = 'hostnet-entity';
+    private const string EXTRA_ENTITY_BUNDLE_DIR = 'entity-bundle-dir';
+    public const string GENERATE_INTERFACES      = 'generate-interfaces';
 
     private $compound_generators;
 

--- a/src/PackageContent.php
+++ b/src/PackageContent.php
@@ -11,8 +11,8 @@ namespace Hostnet\Component\EntityPlugin;
  */
 class PackageContent implements PackageContentInterface
 {
-    public const ENTITY     = '\\Entity\\';
-    public const REPOSITORY = '\\Repository\\';
+    public const string ENTITY     = '\\Entity\\';
+    public const string REPOSITORY = '\\Repository\\';
 
     private $class_map;
     private $type;

--- a/src/ReflectionTypeInterface.php
+++ b/src/ReflectionTypeInterface.php
@@ -8,7 +8,7 @@ namespace Hostnet\Component\EntityPlugin;
 
 interface ReflectionTypeInterface
 {
-    public const NON_QUALIFIED_TYPES = [
+    public const array NON_QUALIFIED_TYPES = [
         'null',
         'void',
         'self',

--- a/test/ReflectionParameterTest.php
+++ b/test/ReflectionParameterTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Input\InputArgument;
  */
 class ReflectionParameterTest extends TestCase
 {
-    private const FOO = 'BAR';
+    private const string FOO = 'BAR';
 
     private function method($param, \Exception $param_2, array $param_3 = null, $param_4 = \DateTime::ATOM): void
     {


### PR DESCRIPTION
- Removes seemningly unused doctrine/annotations dependency
- Drops support for PHP <8.3